### PR TITLE
Corrected logic error in rsslogger

### DIFF
--- a/plugins/rsslogger.rb
+++ b/plugins/rsslogger.rb
@@ -66,7 +66,11 @@ class RSSLogger < Slogger
   end
 
   def parse_feed(rss_feed)
-    markdownify = config['markdownify_posts'] || true
+    markdownify = config['markdownify_posts']
+    unless (markdownify.is_a? TrueClass or markdownify.is_a? FalseClass)
+      markdownify = true
+    end
+
     starred = config['star_posts'] || true
     tags = config['tags'] || ''
     tags = "\n\n#{@tags}\n" unless @tags == ''


### PR DESCRIPTION
regardless of what markdownify_posts was set to
in the config file it would always get set to true
at runtime
