### PR TITLE
Updates in the Flickrlogger plugin

### DIFF
--- a/plugins/flickrlogger.rb
+++ b/plugins/flickrlogger.rb
@@ -16,10 +16,12 @@ config = {
   'flickr_description' => [
     'Logs today\'s photos from Flickr.',
     'flickr_ids is an array of one or more IDs',
+    'flickr_datetype can be the "upload" or "taken" date that has tpo be used',
     'Get your Flickr ID at <http://idgettr.com/>',
     'Get your Flickr API key at <http://www.flickr.com/services/apps/create/noncommercial/>'],
   'flickr_api_key' => '',
   'flickr_ids' => [],
+  'flickr_datetype' => 'upload',
   'flickr_tags' => '@social @photo'
 }
 $slog.register_plugin({ 'class' => 'FlickrLogger', 'config' => config })
@@ -36,6 +38,8 @@ class FlickrLogger < Slogger
       options = {}
       options['content'] = image['content']
       options['uuid'] = %x{uuidgen}.gsub(/-/,'').strip
+      options['datestamp'] = image['date']
+      puts options['datestamp']
       sl = DayOne.new
       path = sl.save_image(image['url'],options['uuid'])
       sl.store_single_photo(path,options)
@@ -65,15 +69,28 @@ class FlickrLogger < Slogger
     images = []
     begin
       config['flickr_ids'].each do |user|
-
-        open("http://www.flickr.com/services/rest/?method=flickr.people.getPublicPhotos&api_key=#{config['flickr_api_key']}&user_id=#{user}&extras=description,date_upload,url_m&per_page=15") { |f|
+        open("http://www.flickr.com/services/rest/?method=flickr.people.getPublicPhotos&api_key=#{config['flickr_api_key']}&user_id=#{user}&extras=description,date_upload,date_taken,url_m&per_page=15") { |f|
             REXML::Document.new(f.read).elements.each("rsp/photos/photo") { |photo|
-              photo_date = photo.attributes["dateupload"].to_s
-              break unless Time.at(photo_date.to_i) > @timespan
+              if config.key?('flickr_datetype') && config['flickr_datetype'] == 'taken'
+                # import images in dayone using the date/time when the photo was taken
+                photo_date = photo.attributes["datetaken"].to_s
+                photo_date = DateTime.now
+                # compensate for current timezone (will not compensate for DST, because it takes the current system timezone)
+                zone = photo_date.zone
+                photo_date = DateTime.parse(photo.attributes["datetaken"] + zone)
+                photo_date = photo_date.strftime('%s').to_s
+                break unless Time.at(photo_date.to_i).utc > @timespan.utc
+                image_date = Time.at(photo_date.to_i).utc.iso8601                
+              else 
+                # import images in dayone using the date/time when the photo was taken
+                photo_date = photo.attributes["dateupload"].to_s
+                break unless Time.at(photo_date.to_i) > @timespan
+                image_date = Time.at(photo_date.to_i).utc.iso8601
+              end              
               url = photo.attributes["url_m"]
               content = "## " + photo.attributes['title']
               content += "\n\n" + photo.attributes['content'] unless photo.attributes['content'].nil?
-              images << { 'content' => content, 'date' => Time.at(photo_date.to_i).utc.iso8601, 'url' => url }
+              images << { 'content' => content, 'date' => image_date, 'url' => url }
             }
         }
       end


### PR DESCRIPTION
When running an import with history (more than one day) all images were
put on the current day, instead of on the day that was passed by Flickr.
It now passes the date from Flickr and uses this as the DayOne date.

Added a configuration option **flickr_datetype** that can be set to
`taken` it then fetches the images and puts them on the date in DayOne on which the images were taken, instead of the day they were uploaded to Flickr.
