### PR TITLE
FacebookIFTTTLogger

### DIFF
--- a/plugins_disabled/facebookifttt.rb
+++ b/plugins_disabled/facebookifttt.rb
@@ -61,7 +61,6 @@ class FacebookIFTTTLogger < Slogger
 
     @log.info("Logging FacebookIFTTTLogger posts at #{inputFile}")
 
-    r = /^(\- )+\Z/
     regPost = /^Post: /
     regDate = /^Date: /
     ampm    = /(AM|PM)\Z/
@@ -79,7 +78,6 @@ class FacebookIFTTTLogger < Slogger
     f.close
 
     content.each do |line|
-      unless line =~ r || line.nil?
 			 if line =~ regPost
 			   	line = line.gsub(regPost, "")
 				  options['content'] = "#### FacebookIFTTT\n\n#{line}\n\n#{tags}"


### PR DESCRIPTION
I've added facebookiftttlogger.rb to plugins_disabled.  This requires an IFTTT recipe to write Facebook status posts to a Dropbox folder/text file.  The plugin process that file.  The comments link to the IFTTT recipe to use.  I have a sample text file, created by the IFTTT recipe, that I can email you for use in testing.  I didn't think that needed to be added to the repository.

This is my second Ruby script, my first git fork, first pull request.  I hope I'm doing this right.
