### PR TITLE
Fixed getglue date

### DIFF
--- a/plugins_disabled/getgluelogger.rb
+++ b/plugins_disabled/getgluelogger.rb
@@ -67,7 +67,7 @@ class GetglueLogger < Slogger
       content += "* [#{item.pubDate.strftime('%H:%M %p')}](#{item.link}) - #{item.title}\n"
     }
     if content != ''
-      entrytext = "## GetGlue Checkins for #{@timespan.strftime('%m-%d-%Y')}\n\n" + content + "\n#{@tags}"
+      entrytext = "## GetGlue Checkins for #{Time.now.strftime("%m-%d-%Y")}}\n\n" + content + "\n#{@tags}"
     end
 
     # create an options array to pass to 'to_dayone'


### PR DESCRIPTION
I had a problem with the date on the getgluelogger and fixed it. Same for last.fm and foursquare. Just took the Time.now() as it is used on the newer plugins.
