### PR TITLE
Fix date on foursquare entries

### DIFF
--- a/plugins/foursquarelogger.rb
+++ b/plugins/foursquarelogger.rb
@@ -64,7 +64,7 @@ class FoursquareLogger < Slogger
       content += "* [#{item.title}](#{item.link})\n"
     }
     if content != ''
-      entrytext = "## Foursquare Checkins for #{@timespan.strftime('%m-%d-%Y')}\n\n" + content + "\n#{@tags}"
+      entrytext = "## Foursquare Checkins for #{Time.now.strftime('%m-%d-%Y')}\n\n" + content + "\n#{@tags}"
     end
     DayOne.new.to_dayone({'content' => entrytext}) unless entrytext == ''
   end


### PR DESCRIPTION
The date on all entries are set a day off. Switched from @timespan to Time.now().
