### PR TITLE
Fixed character encoding issue in OmniFocus plugin

### DIFF
--- a/plugins_disabled/omnifocus.rb
+++ b/plugins_disabled/omnifocus.rb
@@ -35,7 +35,7 @@ class OmniFocusLogger < Slogger
       set dteToday to date (short date string of (current date))
       tell application id "com.omnigroup.OmniFocus"
         tell default document
-          set refDoneToday to a reference to (flattened tasks where (completion date ≥ dteToday))
+          set refDoneToday to a reference to (flattened tasks where (completion date >= dteToday))
           set {lstName, lstContext, lstProject} to {name, name of its context, name of its containing project} of refDoneToday
           set strText to ""
           repeat with iTask from 1 to count of lstName


### PR DESCRIPTION
Upon running `./slogger` to create config files, I was getting the following error associated with `omnifocus.rb` on line 34:

```
invalid multibyte char (US-ASCII)
```

Replacing the `≥` in the AppleScript block with a simpler `>=` fixed the problem.
