### PR TITLE
Escape brackets/parentheses in LastFM song titles

### DIFF
--- a/plugins/lastfmlogger.rb
+++ b/plugins/lastfmlogger.rb
@@ -57,7 +57,9 @@ class LastFMLogger < Slogger
       rss = RSS::Parser.parse(rss_content, false)
       rss.items.each { |item|
         break if Time.parse(item.pubDate.to_s) < today
-        content += "* [#{item.title}](#{item.link})\n"
+        title = String(item.title).e_link()
+        link = String(item.link).e_link()
+        content += "* [#{title}](#{link})\n"
       }
       if content != ''
         entrytext = "#{rss_feed['title']} for #{today.strftime('%m-%d-%Y')}\n\n" + content + "\n#{tags}"

--- a/slogger.rb
+++ b/slogger.rb
@@ -38,6 +38,10 @@ class String
     self.to_s.gsub(/(?=[^a-zA-Z0-9_.\/\-\n])/, '\\').gsub(/\n/, "'\n'").sub(/^$/, "''")
   end
 
+  def e_link
+    self.to_s.gsub(/([\[\]\(\)])/, '\\\\\1')
+  end
+
 end
 
 class Slogger


### PR DESCRIPTION
Currently, lastfmlogger.rb puts out incorrect Markdown links if the artist or song name has a parenthesis in it.

Example entry:
- [Zveri (Звери) – Rayonykvartaly (РайоныКварталы)](http://www.last.fm/music/Zveri+%28%D0%97%D0%B2%D0%B5%D1%80%D0%B8%29/_/Rayonykvartaly+%28%D0%A0%D0%B0%D0%B9%D0%BE%D0%BD%D1%8B%D0%9A%D0%B2%D0%B0%D1%80%D1%82%D0%B0%D0%BB%D1%8B%29)

Fixed entry:
- [Zveri (Звери) – Rayonykvartaly (РайоныКварталы)](http://www.last.fm/music/Zveri+%28%D0%97%D0%B2%D0%B5%D1%80%D0%B8%29/_/Rayonykvartaly+%28%D0%A0%D0%B0%D0%B9%D0%BE%D0%BD%D1%8B%D0%9A%D0%B2%D0%B0%D1%80%D1%82%D0%B0%D0%BB%D1%8B%29)

I added String:e_link() to escape brackets and parentheses, in case this needed to be done in other plugins. I modified lastfmlogger.rb to create String's for song title and link and escape them properly.
