### PR TITLE
Fix each_line separator for Applescript output

### DIFF
--- a/plugins_disabled/omnifocus.rb
+++ b/plugins_disabled/omnifocus.rb
@@ -49,7 +49,7 @@ class OmniFocusLogger < Slogger
       end tell
       return strText
     APPLESCRIPT}
-    values.each_line do |value|
+    values.each_line(sep="\r") do |value|
       # Create entries here
       output += "* " + value + "\n"
     end


### PR DESCRIPTION
The default line separator used by each_line doesn't see that the Applescript output from OmniFocus is multiple lines, so use \r instead.
