### PR TITLE
Make it possible to use ~ in facebook file path

### DIFF
--- a/plugins_disabled/facebookifttt.rb
+++ b/plugins_disabled/facebookifttt.rb
@@ -73,7 +73,7 @@ class FacebookIFTTTLogger < Slogger
     options['starred'] = config['facebook_ifttt_star']
     options['uuid'] = %x{uuidgen}.gsub(/-/,'').strip
 
-    f = File.new(inputFile)
+    f = File.new(File.expand_path(inputFile))
     content = f.read
     f.close
 


### PR DESCRIPTION
Adds `File.expand_path` to facebookifttt so that it's possible to use `~` in `facebook_ifttt_input_file`

Example:
`facebook_ifttt_input_file: "~/Dropbox/AppData/ifttt/facebook/facebook.md.txt"`
