### PR TITLE
Fix to OmniFocus output

### DIFF
--- a/plugins_disabled/omnifocus.rb
+++ b/plugins_disabled/omnifocus.rb
@@ -49,9 +49,9 @@ class OmniFocusLogger < Slogger
       end tell
       return strText
     APPLESCRIPT}
-    values.each_line do |value|
+    values.squeeze("\n").each_line do |value|
       # Create entries here
-      output += "* " + value + "\n"
+      output += "* " + value
     end
 
     # Create a journal entry


### PR DESCRIPTION
OmniFocus tasks were being returned as a single line. Changing from `return` (\r) to `linefeed` (\n) in the Applescript fixes that. Also cleaned up empty lines in the output.
