### PR TITLE
Set up tagging using Day One's XML-based tags

### DIFF
--- a/lib/dayone.rb
+++ b/lib/dayone.rb
@@ -3,6 +3,7 @@ class DayOne < Slogger
     @dayonepath = storage_path
     markdown = @dayonepath =~ /Journal[._]dayone\/?$/ ? false : true
     content = options['content'] || ''
+    tags = options['tags'] || false
     unless markdown
       uuid = options['uuid'] || %x{uuidgen}.gsub(/-/,'').strip
       datestamp = options['datestamp'] || Time.now.utc.iso8601
@@ -105,6 +106,7 @@ class DayOne < Slogger
     options['uuid'] ||= %x{uuidgen}.gsub(/-/,'').strip
     options['starred'] ||= false
     options['datestamp'] ||= Time.now.utc.iso8601
+    options['tags'] ||= false
     photo_dir = File.join(File.expand_path(Slogger.new.storage_path), "photos")
     Dir.mkdir(photo_dir, 0700) unless File.directory?(photo_dir)
 

--- a/plugin_template.rb
+++ b/plugin_template.rb
@@ -15,7 +15,7 @@ config = { # description and a primary key (username, url, etc.) required
                     'line 2, continue array as needed'],
   'service_username' => '', # update the name and make this a string or an array if you want to handle multiple accounts.
   'additional_config_option' => false
-  'tags' => '@social @blogging' # A good idea to provide this with an appropriate default setting
+  'tags' => ['social', 'blogging'] # A good idea to provide this with an appropriate default setting
 }
 # Update the class key to match the unique classname below
 $slog.register_plugin({ 'class' => 'ServiceLogger', 'config' => config })
@@ -44,8 +44,7 @@ class ServiceLogger < Slogger
     @log.info("Logging <Service> posts for #{username}")
 
     additional_config_option = config['additional_config_option'] || false
-    tags = config['tags'] || ''
-    tags = "\n\n#{@tags}\n" unless @tags == ''
+    tags = config['tags'] || false
 
     today = @timespan
 
@@ -54,10 +53,11 @@ class ServiceLogger < Slogger
     # create an options array to pass to 'to_dayone'
     # all options have default fallbacks, so you only need to create the options you want to specify
     options = {}
-    options['content'] = "## Post title\n\nContent#{tags}"
+    options['content'] = "## Post title\n\nContent"
     options['datestamp'] = Time.now.utc.iso8601
     options['starred'] = true
     options['uuid'] = %x{uuidgen}.gsub(/-/,'').strip
+    options['tags'] = tags
 
     # Create a journal entry
     # to_dayone accepts all of the above options as a hash

--- a/plugins/BlogLogger.rb
+++ b/plugins/BlogLogger.rb
@@ -27,7 +27,7 @@ config = {
   'blog_feeds' => [],
   'markdownify_posts' => false,
   'star_posts' => false,
-  'blog_tags' => '@social @blogging',
+  'blog_tags' => ['social', 'blogging'],
   'full_posts' => false
 }
 $slog.register_plugin({ 'class' => 'BlogLogger', 'config' => config })
@@ -78,8 +78,7 @@ class BlogLogger < Slogger
     unless (starred.is_a? TrueClass or starred.is_a? FalseClass)
       starred = true
     end
-    tags = @blogconfig['blog_tags'] || ''
-    tags = "\n\n#{tags}\n" unless tags == ''
+    tags = @blogconfig['blog_tags'] || false
 
     today = @timespan
     begin
@@ -110,10 +109,11 @@ class BlogLogger < Slogger
           content = content.markdownify if markdownify rescue ''
 
           options = {}
-          options['content'] = "## [#{item.title.gsub(/\n+/,' ').strip}](#{item.link})\n\n#{content.strip}#{tags}"
+          options['content'] = "## [#{item.title.gsub(/\n+/,' ').strip}](#{item.link})\n\n#{content.strip}"
           options['datestamp'] = item.date.utc.iso8601 rescue item.dc_date.utc.iso8601
           options['starred'] = starred
           options['uuid'] = %x{uuidgen}.gsub(/-/,'').strip
+          options['tags'] = tags
           sl = DayOne.new
           sl.save_image(imageurl,options['uuid']) if imageurl
           sl.to_dayone(options)

--- a/plugins/appnetlogger.rb
+++ b/plugins/appnetlogger.rb
@@ -6,7 +6,7 @@ Notes:
 Author: [Alan Schussman](http://schussman.com)
 Configuration:
   appnet_usernames: [ ]
-  appnet_tags: "@social @appnet"
+  appnet_tags: ["social", "appnet"]
   appnet_save_replies: false
 Notes:
 
@@ -16,7 +16,7 @@ config = {
     'Logs posts for today from App.net',
     'appnet_usernames is an array of App.net user names'],
   'appnet_usernames' => [ ],
-  'appnet_tags' => '@social @appnet',
+  'appnet_tags' => ['social', 'appnet'],
   'appnet_save_replies' => false
 }
 $slog.register_plugin({ 'class' => 'AppNetLogger', 'config' => config })
@@ -38,8 +38,7 @@ class AppNetLogger < Slogger
     end
 
     sl = DayOne.new
-    config['appnet_tags'] ||= ''
-    tags = "\n\n#{config['appnet_tags']}\n" unless config['appnet_tags'] == ''
+    tags = config['appnet_tags'] || false
     today = @timespan.to_i
 
     @log.info("Getting App.net posts for #{config['appnet_usernames'].length} feeds")
@@ -92,7 +91,8 @@ class AppNetLogger < Slogger
     end
     unless output == ''
       options = {}
-      options['content'] = "## App.net posts\n\n#{output}#{tags}"
+      options['content'] = "## App.net posts\n\n#{output}"
+      options['tags'] = tags
       sl.to_dayone(options)
     end
   end

--- a/plugins/flickrlogger.rb
+++ b/plugins/flickrlogger.rb
@@ -8,7 +8,7 @@ Author: [Brett Terpstra](http://brettterpstra.com)
 Configuration:
   flickr_api_key: 'XXXXXXXXXXXXXXXXXXXXXXXXX'
   flickr_ids: [flickr_id1[, flickr_id2...]]
-  flickr_tags: "@social @photo"
+  flickr_tags: ["social", "photo"]
 Notes:
 
 =end
@@ -22,7 +22,7 @@ config = {
   'flickr_api_key' => '',
   'flickr_ids' => [],
   'flickr_datetype' => 'upload',
-  'flickr_tags' => '@social @photo'
+  'flickr_tags' => ['social', 'photo']
 }
 $slog.register_plugin({ 'class' => 'FlickrLogger', 'config' => config })
 
@@ -39,6 +39,7 @@ class FlickrLogger < Slogger
       options['content'] = image['content']
       options['uuid'] = %x{uuidgen}.gsub(/-/,'').strip
       options['datestamp'] = image['date']
+      options['tags'] = image['tags']
       sl = DayOne.new
       path = sl.save_image(image['url'],options['uuid'])
       sl.store_single_photo(path,options) unless path == false
@@ -60,8 +61,7 @@ class FlickrLogger < Slogger
     end
 
     sl = DayOne.new
-    config['flickr_tags'] ||= ''
-    tags = "\n\n#{config['flickr_tags']}\n" unless config['flickr_tags'] == ''
+    tags = config['flickr_tags'] || false
     today = @timespan.to_i
 
     @log.info("Getting Flickr images for #{config['flickr_ids'].join(', ')}")
@@ -89,7 +89,7 @@ class FlickrLogger < Slogger
               url = photo.attributes["url_m"]
               content = "## " + photo.attributes['title']
               content += "\n\n" + photo.attributes['content'] unless photo.attributes['content'].nil?
-              images << { 'content' => content, 'date' => image_date, 'url' => url }
+              images << { 'content' => content, 'date' => image_date, 'url' => url, 'tags' => tags }
             }
         }
       end

--- a/plugins/foursquarelogger.rb
+++ b/plugins/foursquarelogger.rb
@@ -4,7 +4,7 @@ Description: Checks Foursquare feed once a day for that day's posts.
 Author: [Jeff Mueller](https://github.com/jeffmueller)
 Configuration:
   foursquare_feed: "https://feeds.foursquare.com/history/yourfoursquarehistory.rss"
-  foursquare_tags: "@social @checkins"
+  foursquare_tags: ["social", "checkins"]
 Notes:
   Find your feed at <https://foursquare.com/feeds/> (in RSS option)
 =end
@@ -13,7 +13,7 @@ default_config = {
   'description' => [
   'foursquare_feed must refer to the address of your personal feed.','Your feed should be available at <https://foursquare.com/feeds/>'],
   'foursquare_feed' => "",
-  'foursquare_tags' => "@social @checkins"
+  'foursquare_tags' => ["social", "checkins"]
 }
 $slog.register_plugin({ 'class' => 'FoursquareLogger', 'config' => default_config })
 
@@ -34,8 +34,7 @@ class FoursquareLogger < Slogger
 
     @log.info("Getting FourSquare checkins")
 
-    config['foursquare_tags'] ||= ''
-    @tags = "\n\n#{config['foursquare_tags']}\n" unless config['foursquare_tags'] == ''
+    tags = config['foursquare_tags'] || false
     @debug = config['debug'] || false
 
     entrytext = ''
@@ -64,8 +63,12 @@ class FoursquareLogger < Slogger
       content += "* [#{item.title}](#{item.link})\n"
     }
     if content != ''
-      entrytext = "## Foursquare Checkins for #{@timespan.strftime('%m-%d-%Y')}\n\n" + content + "\n#{@tags}"
+      entrytext = "## Foursquare Checkins for #{@timespan.strftime('%m-%d-%Y')}\n\n" + content
     end
-    DayOne.new.to_dayone({'content' => entrytext}) unless entrytext == ''
+    
+    options = {}
+    options['content'] = entrytext
+    options['tags'] = tags
+    DayOne.new.to_dayone(options) unless entrytext == ''
   end
 end

--- a/plugins/githublogger.rb
+++ b/plugins/githublogger.rb
@@ -4,7 +4,7 @@ Description: Logs daily Github activity for the specified user
 Author: [Brett Terpstra](http://brettterpstra.com)
 Configuration:
   github_user: githubuser
-  github_tags: "@social @coding"
+  github_tags: ["social", "coding"]
 Notes:
 
 =end
@@ -12,7 +12,7 @@ Notes:
 config = {
   'description' => ['Logs daily Github activity for the specified user','github_user should be your Github username'],
   'github_user' => '',
-  'github_tags' => '@social @coding',
+  'github_tags' => ['social', 'coding'],
 }
 $slog.register_plugin({ 'class' => 'GithubLogger', 'config' => config })
 
@@ -47,6 +47,8 @@ class GithubLogger < Slogger
       # p e
     end
 
+    tags = config['github_tags'] || false
+
     return false if res.nil?
     json = JSON.parse(res)
 
@@ -76,8 +78,13 @@ class GithubLogger < Slogger
     }
 
     return false if output.strip == ""
-    entry = "## Github activity for #{Time.now.strftime("%m-%d-%Y")}:\n\n#{output}\n#{config['github_tags']}"
-    DayOne.new.to_dayone({ 'content' => entry })
+    entry = "## Github activity for #{Time.now.strftime("%m-%d-%Y")}:\n\n#{output}}"
+
+    options = {}
+    options['content'] = entry
+    options['tags'] = tags
+
+    DayOne.new.to_dayone(options)
   end
 
 end

--- a/plugins/goodreadslogger.rb
+++ b/plugins/goodreadslogger.rb
@@ -6,7 +6,7 @@ Configuration:
   goodreads_feed: "feedurl"
   goodreads_star_posts: true
   goodreads_save_image: true
-  goodreads_tags: "@social @reading"
+  goodreads_tags: "social", "reading"]
 Notes:
   - goodreads_save_image will save the book cover as the main image for the entry
   - goodreads_feed is a string containing the RSS feed for your read books
@@ -22,7 +22,7 @@ config = {
   'goodreads_feed' => '',
   'goodreads_save_image' => false,
   'goodreads_star_posts' => false,
-  'goodreads_tags' => '@social @reading'
+  'goodreads_tags' => ['social', 'reading']
 }
 $slog.register_plugin({ 'class' => 'GoodreadsLogger', 'config' => config })
 
@@ -75,8 +75,7 @@ class GoodreadsLogger < Slogger
       save_image = false
     end
 
-    tags = @grconfig['goodreads_tags'] || ''
-    tags = "\n\n#{tags}\n" unless tags == ''
+    tags = @grconfig['goodreads_tags'] || false
 
     begin
       rss_content = ""
@@ -103,10 +102,11 @@ class GoodreadsLogger < Slogger
           content = content != '' ? "\n\n#{content}" : ''
 
           options = {}
-          options['content'] = "Finished reading [#{item.elements['title'].text.gsub(/\n+/,' ').strip}](#{item.elements['link'].text.strip})#{content}#{tags}"
+          options['content'] = "Finished reading [#{item.elements['title'].text.gsub(/\n+/,' ').strip}](#{item.elements['link'].text.strip})#{content}"
           options['datestamp'] = Time.parse(item.elements['user_read_at'].text).utc.iso8601 rescue Time.parse(item.elements['pubDate'].text).utc.iso8601
           options['starred'] = starred
           options['uuid'] = %x{uuidgen}.gsub(/-/,'').strip
+          options['tags'] = tags
           sl = DayOne.new
           if imageurl
             sl.to_dayone(options) if sl.save_image(imageurl,options['uuid'])

--- a/plugins/instapaperlogger.rb
+++ b/plugins/instapaperlogger.rb
@@ -17,7 +17,7 @@ config = {
     'instapaper_feeds is an array of one or more RSS feeds',
   'Find the RSS feed for any folder at the bottom of a web interface page'],
   'instapaper_feeds' => [],
-  'instapaper_tags' => '@social @reading'
+  'instapaper_tags' => ['social', 'reading']
 }
 $slog.register_plugin({ 'class' => 'InstapaperLogger', 'config' => config })
 
@@ -37,8 +37,7 @@ class InstapaperLogger < Slogger
     end
 
     sl = DayOne.new
-    config['instapaper_tags'] ||= ''
-    tags = "\n\n#{config['instapaper_tags']}\n" unless config['instapaper_tags'] == ''
+    tags = config['instapaper_tags'] || false
     today = @timespan.to_i
 
     @log.info("Getting Instapaper posts for #{config['instapaper_feeds'].length} accounts")
@@ -71,7 +70,8 @@ class InstapaperLogger < Slogger
     end
     unless output.strip == ''
       options = {}
-      options['content'] = "## Instapaper reading\n\n#{output}#{tags}"
+      options['content'] = "## Instapaper reading\n\n#{output}"
+      options['tags'] = tags
       sl.to_dayone(options)
     end
   end

--- a/plugins/lastfmlogger.rb
+++ b/plugins/lastfmlogger.rb
@@ -4,14 +4,14 @@ Description: Logs playlists and loved tracks for the day
 Author: [Brett Terpstra](http://brettterpstra.com)
 Configuration:
   lastfm_user: lastfmusername
-  lastfm_tags: "@social @blogging"
+  lastfm_tags: ["social", "blogging"]
 Notes:
 
 =end
 config = {
   'lastfm_description' => ['Logs songs scrobbled for time period.','lastfm_user is your Last.fm username.'],
   'lastfm_user' => '',
-  'lastfm_tags' => '@social @music'
+  'lastfm_tags' => ["social", "blogging"]
 }
 $slog.register_plugin({ 'class' => 'LastFMLogger', 'config' => config })
 
@@ -31,8 +31,7 @@ class LastFMLogger < Slogger
       return
     end
 
-    config['lastfm_tags'] ||= ''
-    tags = "\n\n#{config['lastfm_tags']}\n" unless config['lastfm_tags'] == ''
+    tags = config['lastfm_tags'] || false
 
     feeds = [{'title'=>"## Listening To", 'feed' => "http://ws.audioscrobbler.com/2.0/user/#{config['lastfm_user']}/recenttracks.rss?limit=100"},{'title'=>"## Loved Tracks", 'feed' => "http://ws.audioscrobbler.com/2.0/user/#{config['lastfm_user']}/lovedtracks.rss?limit=100"}]
 
@@ -62,9 +61,14 @@ class LastFMLogger < Slogger
         content += "* [#{title}](#{link})\n"
       }
       if content != ''
-        entrytext = "#{rss_feed['title']} for #{today.strftime('%m-%d-%Y')}\n\n" + content + "\n#{tags}"
+        entrytext = "#{rss_feed['title']} for #{today.strftime('%m-%d-%Y')}\n\n" + content
       end
-      DayOne.new.to_dayone({'content' => entrytext}) unless entrytext == ''
+
+      options = {}
+      options['content'] = entrytext
+      options['tags'] = tags
+
+      DayOne.new.to_dayone(options) unless entrytext == ''
     end
   end
 end

--- a/plugins/pinboardlogger.rb
+++ b/plugins/pinboardlogger.rb
@@ -7,7 +7,7 @@ Notes:
 Author: [Brett Terpstra](http://brettterpstra.com)
 Configuration:
   pinboard_feeds: [ 'http://feeds.pinboard.in/rss/u:username/']
-  pinboard_tags: "@social @bookmarks"
+  pinboard_tags: ["social", "bookmarks"]
 Notes:
 
 =end
@@ -16,7 +16,7 @@ config = {
     'Logs bookmarks for today from Pinboard.in.',
     'pinboard_feeds is an array of one or more Pinboard RSS feeds'],
   'pinboard_feeds' => [],
-  'pinboard_tags' => '@social @bookmarks',
+  'pinboard_tags' => ['social', 'bookmarks'],
   'pinboard_save_hashtags' => true
 }
 $slog.register_plugin({ 'class' => 'PinboardLogger', 'config' => config })
@@ -38,8 +38,7 @@ class PinboardLogger < Slogger
     end
 
     sl = DayOne.new
-    config['pinboard_tags'] ||= ''
-    tags = "\n\n#{config['pinboard_tags']}\n" unless config['pinboard_tags'] == ''
+    tags = config['pinboard_tags'] || false
     today = @timespan.to_i
 
     @log.info("Getting Pinboard bookmarks for #{config['pinboard_feeds'].length} feeds")
@@ -77,7 +76,8 @@ class PinboardLogger < Slogger
     end
     unless output == ''
       options = {}
-      options['content'] = "## Pinboard bookmarks\n\n#{output}#{tags}"
+      options['content'] = "## Pinboard bookmarks\n\n#{output}"
+      options['tags'] = tags
       sl.to_dayone(options)
     end
   end

--- a/plugins/pocketlogger.rb
+++ b/plugins/pocketlogger.rb
@@ -6,7 +6,7 @@ Notes:
 Author: [Brett Terpstra](http://brettterpstra.com)
 Configuration:
   pocket_username: 'your_username'
-  pocket_tags: "@social @reading"
+  pocket_tags: ["social", "reading"]
 Notes:
 
 =end
@@ -15,7 +15,7 @@ config = {
     'Logs today\'s posts to Pocket.',
     'pocket_username is a string with your Pocket username'],
   'pocket_username' => '',
-  'pocket_tags' => '@social @reading'
+  'pocket_tags' => ['social', 'reading']
 }
 $slog.register_plugin({ 'class' => 'PocketLogger', 'config' => config })
 
@@ -35,9 +35,8 @@ class PocketLogger < Slogger
     end
 
     sl = DayOne.new
-    config['pocket_tags'] ||= ''
+    tags = config['pocket_tags'] || false
     username = config['pocket_username']
-    tags = "\n\n#{config['pocket_tags']}\n" unless config['pocket_tags'] == ''
     today = @timespan
 
     @log.info("Getting Pocket posts for #{username}")
@@ -67,7 +66,8 @@ class PocketLogger < Slogger
     end
     unless output == ''
       options = {}
-      options['content'] = "## Pocket reading\n\n#{output}#{tags}"
+      options['content'] = "## Pocket reading\n\n#{output}"
+      options['tags'] = tags
       sl.to_dayone(options)
     end
   end

--- a/plugins/rsslogger.rb
+++ b/plugins/rsslogger.rb
@@ -4,18 +4,18 @@ Description: Logs any RSS feed as a digest and checks for new posts for the curr
 Author: [Brett Terpstra](http://brettterpstra.com)
 Configuration:
   feeds: [ "feed url 1" , "feed url 2", ... ]
-  tags: "@social @rss"
+  tags: ["social", "rss"]
 Notes:
   - rss_feeds is an array of feeds separated by commas, a single feed is fine, but it should be inside of brackets `[]`
-  - rss_tags are tags you want to add to every entry, e.g. "@social @rss"
+  - rss_tags are tags you want to add to every entry, e.g. ["social", "rss"]
 =end
 
 config = {
   'description' => ['Logs any RSS feed as a digest and checks for new posts for the current day',
                     'feeds is an array of feeds separated by commas, a single feed is fine, but it should be inside of brackets `[]`',
-                    'tags are tags you want to add to every entry, e.g. "@social @rss"'],
+                    'tags are tags you want to add to every entry, e.g. ["social", "rss"]'],
   'feeds' => [],
-  'tags' => '@social @rss'
+  'tags' => ['social', 'rss']
 }
 $slog.register_plugin({ 'class' => 'RSSLogger', 'config' => config })
 
@@ -58,8 +58,7 @@ class RSSLogger < Slogger
 
   def parse_feed(rss_feed)
 
-    tags = @rssconfig['tags'] || ''
-    tags = "\n\n#{tags}\n" unless tags == ''
+    tags = @rssconfig['tags'] || false
 
     today = @timespan
     begin
@@ -97,7 +96,8 @@ class RSSLogger < Slogger
 
       if feed_items.length > 0
         options = {}
-        options['content'] = "## #{rss.channel.title.gsub(/\n+/,' ').strip}\n\n#{feed_items.reverse.join("\n")}#{tags}"
+        options['content'] = "## #{rss.channel.title.gsub(/\n+/,' ').strip}\n\n#{feed_items.reverse.join("\n")}"
+        options['tags'] = tags
         sl = DayOne.new
         sl.to_dayone(options)
       end

--- a/plugins/twitterlogger.rb
+++ b/plugins/twitterlogger.rb
@@ -6,7 +6,9 @@ Configuration:
   twitter_users: [ "handle1" , "handle2", ... ]
   save_images: true
   droplr_domain: d.pr
-  twitter_tags: "@social @blogging"
+  twitter_tags:
+    -social
+    -blogging
 Notes:
 
 =end
@@ -21,7 +23,7 @@ config = {
   'save_favorites' => true,
   'save_images' => true,
   'droplr_domain' => 'd.pr',
-  'twitter_tags' => '@social @twitter'
+  'twitter_tags' => ['social', 'twitter']
 }
 $slog.register_plugin({ 'class' => 'TwitterLogger', 'config' => config })
 
@@ -174,8 +176,7 @@ class TwitterLogger < Slogger
     @twitter_config['droplr_domain'] ||= 'd.pr'
 
     sl = DayOne.new
-    @twitter_config['twitter_tags'] ||= ''
-    tags = "\n\n#{@twitter_config['twitter_tags']}\n" unless @twitter_config['twitter_tags'] == ''
+    tags = @twitter_config['twitter_tags'] || false
 
     @twitter_config['twitter_users'].each do |user|
       retries = 0
@@ -209,12 +210,19 @@ class TwitterLogger < Slogger
         favs = ''
       end
       unless tweets == ''
-        tweets = "## Tweets\n\n### Posts by @#{user} on #{Time.now.strftime('%m-%d-%Y')}\n\n#{tweets}#{tags}"
-        sl.to_dayone({'content' => tweets})
+        tweets = "## Tweets\n\n### Posts by @#{user} on #{Time.now.strftime('%m-%d-%Y')}\n\n#{tweets}"
+        options = {}
+        options['content'] = tweets
+        options['tags'] = tags
+
+        sl.to_dayone(options)
       end
       unless favs == ''
-        favs = "## Favorite Tweets\n\n### Favorites from @#{user} for #{Time.now.strftime('%m-%d-%Y')}\n\n#{favs}#{tags}"
-        sl.to_dayone({'content' => favs})
+        favs = "## Favorite Tweets\n\n### Favorites from @#{user} for #{Time.now.strftime('%m-%d-%Y')}\n\n#{favs}"
+        options = {}
+        options['content'] = favs
+        options['tags'] = tags
+        sl.to_dayone(options)
       end
     end
   end

--- a/plugins_disabled/facebookifttt.rb
+++ b/plugins_disabled/facebookifttt.rb
@@ -33,7 +33,7 @@ config = {
                     'The recipe at https://ifttt.com/recipes/56242 determines that location.'],
   'facebook_ifttt_input_file' => '', 
   'facebook_ifttt_star' => false,
-  'facebook_ifttt_tags' => '@social @blogging'
+  'facebook_ifttt_tags' => ['social', 'blogging']
 }
 
 $slog.register_plugin({ 'class' => 'FacebookIFTTTLogger', 'config' => config })
@@ -54,8 +54,7 @@ class FacebookIFTTTLogger < Slogger
       	return
     end
 
-    tags = config['facebook_ifttt_tags'] || ''
-    tags = "\n\n#{@tags}\n" unless @tags == ''
+    tags = config['facebook_ifttt_tags'] || false
 
     inputFile = config['facebook_ifttt_input_file']
 
@@ -72,6 +71,7 @@ class FacebookIFTTTLogger < Slogger
     options = {}
     options['starred'] = config['facebook_ifttt_star']
     options['uuid'] = %x{uuidgen}.gsub(/-/,'').strip
+    options['tags'] = tags
 
     f = File.new(File.expand_path(inputFile))
     content = f.read
@@ -81,7 +81,7 @@ class FacebookIFTTTLogger < Slogger
       content.each do |line|
   			 if line =~ regPost
   			   	line = line.gsub(regPost, "")
-  				  options['content'] = "#### FacebookIFTTT\n\n#{line}\n\n#{tags}"
+  				  options['content'] = "#### FacebookIFTTT\n\n#{line}"
             ready = false
   			 elsif line =~ regDate
   		 	  line = line.strip

--- a/plugins_disabled/feedlogger.rb
+++ b/plugins_disabled/feedlogger.rb
@@ -6,13 +6,13 @@ Configuration:
   feeds: [ "feed url 1" , "feed url 2", ... ]
   markdownify_posts: true
   star_posts: true
-  tags: "@social @blogging"
+  tags: ["social", "blogging"]
 Notes:
   - if found, the first image in the post will be saved as the main image for the entry
   - atom_feeds is an array of feeds separated by commas, a single feed is fine, but it should be inside of brackets `[]`
   - markdownify_posts will convert links and emphasis in the post to Markdown for display in Day One
   - star_posts will create a starred post for new atom posts
-  - atom_tags are tags you want to add to every entry, e.g. "@social @blogging"
+  - atom_tags are tags you want to add to every entry, e.g. ["social", "blogging"]
 =end
 
 require 'feed-normalizer'
@@ -22,11 +22,11 @@ config = {
                     'feeds is an array of feeds separated by commas, a single feed is fine, but it should be inside of brackets `[]`',
                     'markdownify_posts will convert links and emphasis in the post to Markdown for display in Day One',
                     'star_posts will create a starred post for new posts',
-                    'tags are tags you want to add to every entry, e.g. "@social @blogging"'],
+                    'tags are tags you want to add to every entry, e.g. ["social", "blogging"]'],
   'feeds' => [],
   'markdownify_posts' => true,
   'star_posts' => false,
-  'tags' => '@social @blogging'
+  'tags' => ['social', 'blogging']
 }
 $slog.register_plugin({ 'class' => 'FeedLogger', 'config' => config })
 
@@ -76,8 +76,7 @@ class FeedLogger < Slogger
     unless (starred.is_a? TrueClass or starred.is_a? FalseClass)
       starred = true
     end
-    tags = config['tags'] || ''
-    tags = "\n\n#{@tags}\n" unless @tags == ''
+    tags = config['tags'] || false
 
     today = @timespan
     begin
@@ -111,10 +110,11 @@ class FeedLogger < Slogger
           end
 
           options = {}
-          options['content'] = "## [#{entry.title.gsub(/\n+/,' ').strip}](#{entry.url})\n\n#{content.strip}#{tags}"
+          options['content'] = "## [#{entry.title.gsub(/\n+/,' ').strip}](#{entry.url})\n\n#{content.strip}"
           options['datestamp'] = entry.date_published.utc.iso8601 rescue Time.now.utc.iso8601
           options['starred'] = starred
           options['uuid'] = %x{uuidgen}.gsub(/-/,'').strip
+          options['tags'] = tags
 
           sl = DayOne.new
           if imageurl

--- a/plugins_disabled/flickrlogger_rss.rb
+++ b/plugins_disabled/flickrlogger_rss.rb
@@ -4,14 +4,14 @@ Description: Logs today's photos from Flickr RSS feed. Get your Flickr ID at <ht
 Author: [Brett Terpstra](http://brettterpstra.com)
 Configuration:
   flickr_ids: [flickr_id1[, flickr_id2...]]
-  flickr_tags: "@social @photo"
+  flickr_tags: ["social", "photo"]
 Notes:
   - This version uses the RSS feed. This can take up to four hours to update, which is why I wrote the default API version. I'm impatient
 =end
 config = {
   'description' => ['flickr_ids should be an array with one or more Flickr user ids (http://idgettr.com/)']
   'flickr_ids' => [],
-  'flickr_tags' => '@social @photo'
+  'flickr_tags' => ['social', 'photo']
 }
 $slog.register_plugin({ 'class' => 'FlickrLogger', 'config' => config })
 
@@ -27,6 +27,7 @@ class FlickrLogger < Slogger
       options = {}
       options['content'] = image['content']
       options['uuid'] = %x{uuidgen}.gsub(/-/,'').strip
+      options['tags'] = image['tags']
       sl = DayOne.new
       path = sl.save_image(image['url'],options['uuid'])
       sl.store_single_photo(path,options)
@@ -48,8 +49,7 @@ class FlickrLogger < Slogger
     end
 
     sl = DayOne.new
-    config['flickr_tags'] ||= ''
-    tags = "\n\n#{config['flickr_tags']}\n" unless config['flickr_tags'] == ''
+    tags = config['flickr_tags'] || false
 
     @log.info("Getting Flickr images for #{config['flickr_ids'].join(', ')}")
     url = URI.parse("http://api.flickr.com/services/feeds/photos_public.gne?ids=#{config['flickr_ids'].join(',')}")
@@ -69,7 +69,7 @@ class FlickrLogger < Slogger
         content = "## " + photo.elements['title'].text
         url = photo.elements['link'].text
         content += "\n\n" + photo.elements['content'].text.markdownify unless photo.elements['content'].text == ''
-        images << { 'content' => content, 'date' => photo_date.utc.iso8601, 'url' => url }
+        images << { 'content' => content, 'date' => photo_date.utc.iso8601, 'url' => url, 'tags' => tags }
       }
     rescue Exception => e
       puts "Error getting photos for #{config['flickr_ids'].join(', ')}"

--- a/plugins_disabled/getgluelogger.rb
+++ b/plugins_disabled/getgluelogger.rb
@@ -14,7 +14,7 @@ config = {
                     'You will need the RSS feed of your Activity stream.'],
   'getglue_username' => 'getglue',
   'getglue_feed' => "",
-  'tags' => '@social @entertainment'
+  'tags' => ['social', 'entertainment']
 }
 
 $slog.register_plugin({ 'class' => 'GetglueLogger', 'config' => config })
@@ -43,8 +43,7 @@ class GetglueLogger < Slogger
     @log.info("Logging GetGlue posts for #{username}")
     @feed = config['getglue_feed']
 
-    tags = config['tags'] || ''
-    tags = "\n\n#{@tags}\n" unless @tags == ''
+    tags = config['tags'] || false
 
     today = @timespan
 
@@ -71,16 +70,17 @@ class GetglueLogger < Slogger
       end
     }
     if content != ''
-      entrytext = "## GetGlue Checkins for #{@timespan.strftime('%m-%d-%Y')}\n\n" + content + "\n#{@tags}"
+      entrytext = "## GetGlue Checkins for #{@timespan.strftime('%m-%d-%Y')}\n\n" + content
     end
 
     # create an options array to pass to 'to_dayone'
     # all options have default fallbacks, so you only need to create the options you want to specify
     if content != ''
       options = {}
-      options['content'] = "## GetGlue Activity for #{@timespan.strftime('%m-%d-%Y')}\n\n#{content} #{tags}"
+      options['content'] = "## GetGlue Activity for #{@timespan.strftime('%m-%d-%Y')}\n\n#{content}"
       options['datestamp'] = @timespan.utc.iso8601
       options['uuid'] = %x{uuidgen}.gsub(/-/,'').strip
+      options['tags'] = tags
 
 
       # Create a journal entry

--- a/plugins_disabled/gistlogger.rb
+++ b/plugins_disabled/gistlogger.rb
@@ -4,7 +4,7 @@ Description: Logs daily Gists for the specified user
 Author: [Brett Terpstra](http://brettterpstra.com)
 Configuration:
   gist_user: githubuser
-  gist_tags: "@social @coding"
+  gist_tags: ["social", "coding"]
 Notes:
 
 =end
@@ -12,7 +12,7 @@ Notes:
 config = {
   'description' => ['Logs daily Gists for the specified user','gist_user should be your Github username'],
   'gist_user' => '',
-  'gist_tags' => '@social @coding',
+  'gist_tags' => ['social', 'coding'],
 }
 $slog.register_plugin({ 'class' => 'GistLogger', 'config' => config })
 
@@ -29,6 +29,9 @@ class GistLogger < Slogger
       @log.warn("Gist user has not been configured, please edit your slogger_config file.")
       return
     end
+
+    tags = config['gist_tags'] || false
+
     @log.info("Logging gists for #{config['gist_user']}")
     begin
       url = URI.parse "https://api.github.com/users/#{config['gist_user']}/gists"
@@ -66,8 +69,13 @@ class GistLogger < Slogger
     }
 
     return false if output.strip == ""
-    entry = "## Gists for #{Time.now.strftime("%m-%d-%Y")}:\n\n#{output}\n#{config['gist_tags']}"
-    DayOne.new.to_dayone({ 'content' => entry })
+    entry = "## Gists for #{Time.now.strftime("%m-%d-%Y")}:\n\n#{output}"
+
+    options = {}
+    options['content'] = entry
+    options['tags'] = tags
+
+    DayOne.new.to_dayone(options)
   end
 
 end

--- a/plugins_disabled/googleanalyticslogger.rb
+++ b/plugins_disabled/googleanalyticslogger.rb
@@ -60,7 +60,7 @@ config = { # description and a primary key (username, url, etc.) required
   'properties' => [],
   'show_sources' => true,
   'show_popular_pages' => true,
-  'tags' => '@social @sitestats'
+  'tags' => ['social', 'sitestats']
 }
 
 # ALERT: This registration assumes `slogger.rb` has been updated
@@ -295,15 +295,15 @@ class GoogleAnalyticsLogger < Slogger
       end
 
       # And create a Journal entry for each date body
-      tags = config['tags'] || ''      
+      tags = config['tags'] || false
       content.each do |key, body|
         logdate = "#{key[0..3]}-#{key[4..5]}-#{key[6..7]}"
-        body << "#{tags}" unless tags == ''
       
         # And Log to Day One
         options = {}
         options['content'] = body.join("\n\n")
         options['datestamp'] = Time.parse(logdate + " 23:59:00").utc.iso8601
+        options['tags'] = tags
 
         sl = DayOne.new
         sl.to_dayone(options)

--- a/plugins_disabled/omnifocus.rb
+++ b/plugins_disabled/omnifocus.rb
@@ -7,7 +7,7 @@ Author: [RichSomerfield](www.richsomerfield.com)
 config = {
   'omnifocus_description' => [
     'Grabs completed tasks from OmniFocus'],
-  'omnifocus_tags' => '@tasks',
+  'omnifocus_tags' => ['tasks'],
   'omnifocus_save_hashtags' => true
 }
 
@@ -16,16 +16,16 @@ $slog.register_plugin({ 'class' => 'OmniFocusLogger', 'config' => config })
 class OmniFocusLogger < Slogger
   def do_log
     if @config.key?(self.class.name)
+      config = @config[self.class.name]
       # We don't have any config, so don't need to worry about it not being there ;-)
     else
-      @log.warn("<Service> has not been configured or a feed is invalid, please edit your slogger_config file.")
+      @log.warn("Omnifocus has not been configured or a feed is invalid, please edit your slogger_config file.")
       return
     end
-    @log.info("Logging <Service> for completed tasks")
+    @log.info("Logging Omnifocus for completed tasks")
 
     additional_config_option = config['additional_config_option'] || false
-    tags = config['tags'] || ''
-    tags = "\n\n#{@tags}\n" unless @tags == ''
+    tags = config['omnifocus_tags'] || false
 
     today = @timespan
     output = ''
@@ -57,7 +57,8 @@ class OmniFocusLogger < Slogger
     # Create a journal entry
     unless output == ''
       options = {}
-      options['content'] = "## OmniFocus - Completed Tasks\n\n#{output}#{tags}"
+      options['content'] = "## OmniFocus - Completed Tasks\n\n#{output}"
+      options['tags'] = tags
       sl = DayOne.new
       sl.to_dayone(options)
     end

--- a/plugins_disabled/pocketlogger_api.rb
+++ b/plugins_disabled/pocketlogger_api.rb
@@ -7,7 +7,7 @@ Author: [Brett Terpstra](http://brettterpstra.com)
 Configuration:
   pocket_username: "your_username"
   pocket_passwd: "your_password"
-  pocket_tags: "@social @reading"
+  pocket_tags: ["social", "reading"]
   posts_to_get: "read" or "unread" or leave blank for all
 Notes:
 
@@ -21,7 +21,7 @@ config = {
     'posts_to_get allows you to choose read, unread or all items'],
   'pocket_username' => '',
   'pocket_passwd' => '',
-  'pocket_tags' => '@social @reading',
+  'pocket_tags' => ['social', 'reading'],
   'posts_to_get' => ''
 }
 $slog.register_plugin({ 'class' => 'PocketLogger', 'config' => config })
@@ -45,11 +45,10 @@ class PocketLogger < Slogger
     end
 
     sl = DayOne.new
-    config['pocket_tags'] ||= ''
+    tags = config['pocket_tags'] || false
     username = config['pocket_username']
     passwd= config['pocket_passwd']
     posts_to_get=config['posts_to_get']
-    tags = "\n\n#{config['pocket_tags']}\n" unless config['pocket_tags'] == ''
     today = @timespan
     yest=(Time.now-86400).to_i
     pkey="29ed8r79To6fuG8e9bA480GD77g5P586"
@@ -71,7 +70,8 @@ class PocketLogger < Slogger
     end
     unless output == ''
       options = {}
-      options['content'] = "Pocket reading\n\n#{output}#{tags}"
+      options['content'] = "Pocket reading\n\n#{output}"
+      options['tags'] = tags
       sl.to_dayone(options)
     end
   end

--- a/slogger.rb
+++ b/slogger.rb
@@ -194,6 +194,14 @@ class Slogger
   <string><%= entry %></string>
   <key>Starred</key>
   <<%= starred %>/>
+  <% if tags %>
+  <key>Tags</key>
+  <array>
+      <% tags.each do |tag| %>
+      <string><%= tag %></string>
+      <% end %>
+  </array>
+  <% end %>
   <key>UUID</key>
   <string><%= uuid %></string>
 </dict>
@@ -207,6 +215,7 @@ Starred: <%= starred %>
 
 <%= entry %>
 
+<%= tags.join(" ") %>
 MARKDOWNTEMPLATE
     end
   end


### PR DESCRIPTION
Day One introduced native support for tagging in the latest release. This pull request changes tagging in Slogger to match Day One's format, modifying both the XML templates and all plugins to support it.

Tags are marked up in XML as an array with a key of "Tags".

```
<key>Tags</key>
<array>
    <string>tag1</string>
    <string>tag2</string>
</array>
```

This should fix Issue #17.
