### PR TITLE
Facebook: generating new uuid for each entry rather than at start of script.

### DIFF
--- a/plugins_disabled/facebookifttt.rb
+++ b/plugins_disabled/facebookifttt.rb
@@ -118,7 +118,6 @@ class FacebookIFTTTLogger < Slogger
 
         if ready
           sl = DayOne.new
-          options['uuid'] = %x{uuidgen}.gsub(/-/,'').strip
           options['content'] = "#### FacebookIFTTT\n\n#{posttext}\n\n#{tags}"
           sl.to_dayone(options)
           ready = false


### PR DESCRIPTION
Found another bug: the uuid was generated at the start of the script, but a new entry created for every Facebook status. This meant only the last status of the day was actually being posted.

Also introduced a bug with my last fix: was concatenating the contents of EVERY post until one was sent to Day One, meaning the first post of the day was pretty long. :)

This commit fixes both bugs.
