### PR TITLE
New Yahoo Finance logger to save market prices

### DIFF
--- a/plugins_disabled/yahoofinancelogger.rb
+++ b/plugins_disabled/yahoofinancelogger.rb
@@ -55,10 +55,9 @@ class YahooFinanceLogger < Slogger
     end
     
     symbols = tickers.join("+")
-    uri = URI('http://download.finance.yahoo.com/d/quotes.csv')
-    params = { :s => symbols, :f => 'nl1c1oghjkpvrj1' }
-    uri.query = URI.encode_www_form(params)
-
+    symbols = tickers.join("+")
+    uri = URI(URI.escape("http://download.finance.yahoo.com/d/quotes.csv?s=#{symbols}&f=nl1c1oghjkpvrj1"))
+    
     res = Net::HTTP.get_response(uri)
     unless res.is_a?(Net::HTTPSuccess)
       @log.warn("Unable to get data from Yahoo Finance.")


### PR DESCRIPTION
I added a new, very simple plugin, to capture market data from Yahoo. Not sure if anyone will be interested in this but, what the hey, scratches my itch! In plugins_disabled.

For details see http://www.hiltmon.com/blog/2012/12/01/yahoo-finance-logger-for-slogger/
