### PR TITLE
Only resize image if it is too big

### DIFF
--- a/lib/dayone.rb
+++ b/lib/dayone.rb
@@ -73,11 +73,17 @@ class DayOne < Slogger
     return false if match.nil?
     ext = match[1]
     @log.info("Processing image #{File.basename(orig)}")
-    height = Integer(%x{sips --getProperty pixelHeight "#{orig}" 2>&1}.split(":")[1])
-    width = Integer(%x{sips --getProperty pixelWidth "#{orig}" 2>&1}.split(":")[1])
-    if width > 1600 || height > 1600
-      @log.info("Resizing image #{File.basename(orig)}")
-      res = %x{sips -Z 1600 "#{orig}" 2>&1}
+    sips_available = %x{sips 2>&1}
+    if sips_available.include? "command not found"
+      @log.warn("sips not available, cannot resize image")
+      # TODO: fall back on something else to resize images
+    else
+      height = Integer(%x{sips --getProperty pixelHeight "#{orig}" 2>&1}.split(":")[1])
+      width = Integer(%x{sips --getProperty pixelWidth "#{orig}" 2>&1}.split(":")[1])
+      if width > 1600 || height > 1600
+        @log.info("Resizing image #{File.basename(orig)}")
+        res = %x{sips -Z 1600 "#{orig}" 2>&1}
+      end
     end
     unless ext =~ /\.jpg$/
       case ext


### PR DESCRIPTION
Don’t ever scale image up, only scale it down if it’s bigger than the maximum (1600px)
This was reverted in f0407a891308aabb9ecb12416f7cc3c3608cdebf ‘Added native tagging’
