### PR TITLE
GitHubLogger: Fix for PushEvents without repository

### DIFF
--- a/plugins/githublogger.rb
+++ b/plugins/githublogger.rb
@@ -57,6 +57,9 @@ class GithubLogger < Slogger
       if date > @timespan
         case action['type']
           when "PushEvent"
+            if !action["repository"]
+              action['repository'] = {"name" => "unknown repository"}
+            end
             output += "* Pushed to branch *#{action['payload']['ref'].gsub(/refs\/heads\//,'')}* of [#{action['repository']['name']}](#{action['url']})\n"
             action['payload']['shas'].each do |sha|
               output += "    * #{sha[2].gsub(/\n+/," ")}\n" unless sha.length < 3


### PR DESCRIPTION
After deleting a repository, the GitHubLogger would fail because while the PushEvents where still in the feed, the repository wasn’t. Now if there isn’t one, it’ll say ‘unknown repository’.
