### PR TITLE
Fix date extraction when only an updated date has been recognized

### DIFF
--- a/plugins/BlogLogger.rb
+++ b/plugins/BlogLogger.rb
@@ -20,7 +20,7 @@ config = {
                     'blog_feeds is an array of feeds separated by commas, a single feed is fine, but it should be inside of brackets `[]`',
                     'markdownify_posts will convert links and emphasis in the post to Markdown for display in Day One',
                     'star_posts will create a starred post for new RSS posts',
-                    'blog_tags are tags you want to add to every entry, e.g. "#social #rss"',
+                    'blog_tags are tags you want to add to every entry, e.g. "#social #rss"'],
   'blog_feeds' => [],
   'markdownify_posts' => true,
   'star_posts' => false,
@@ -87,9 +87,10 @@ class BlogLogger < Slogger
       rss = RSS::Parser.parse(rss_content, false)
       rss.items.each { |item|
         begin
-          item_date = Time.parse(item.date.to_s) + Time.now.gmt_offset
+          item_date = Time.parse((item.date || item.updated).to_s) + Time.now.gmt_offset
         rescue
-          item_date = Time.parse(item.updated.to_s) + Time.now.gmt_offset
+          @log.warn("Unable to find proper datestamp")
+          item_date = Time.now
         end
         if item_date > today
           content = nil


### PR DESCRIPTION
As per our [Twitter conversation last night](https://twitter.com/ttscoff/status/310894313179594752), here's a pull request to fix the bug that Slogger would always grab all posts from the feed, even when run with a "today" timespan while it did slot the posts into their respective day journals properly.

It turns out that the RSS module fails to recognize the `published` nodes in the Atom feed and thus doesn't return them with `item.date`. As such, `Time.parse` runs with an empty string which happens to yield a `Time` object set to the current date.

I've modified the `begin/rescue` block slightly to run the same line on the two nodes (`date` and `updated`) in succession, which fixes the bug for me. The failback now is the current time again, so if neither `date` nor `updated` is properly recognized you'd end up with duplicate entries again. It could be debated whether the fallback should be `1970-01-01 00:00:00` instead to fail the "today" check, but I guess there is no right answer.

PS: I also took the liberty to fix the parse error due to a missing bracket in the plugin description.
