### PR TITLE
Check for ruby version <2.0.0 when trying to load Syck

### DIFF
--- a/lib/configtools.rb
+++ b/lib/configtools.rb
@@ -3,7 +3,7 @@ require 'yaml'
 class ConfigTools
   attr_accessor :config_file
   def initialize(options)
-    YAML::ENGINE.yamler = 'syck' if defined?(YAML::ENGINE)
+    YAML::ENGINE.yamler = 'syck' if defined?(YAML::ENGINE) && RUBY_VERSION < "2.0.0"
     @config_file = options['config_file']
   end
 


### PR DESCRIPTION
Slogger didn't work for me in Ruby 2.0.0p0 because Syck has been removed from that version of ruby. 

This small patch checks for the ruby version when requiring Syck.
