### PR TITLE
Changed .each to .each_line in Facebookifttt plugin to comply with ruby ...

### DIFF
--- a/plugins_disabled/facebookifttt.rb
+++ b/plugins_disabled/facebookifttt.rb
@@ -80,7 +80,7 @@ class FacebookIFTTTLogger < Slogger
     f.close
 
     if !content.empty?
-      content.each do |line|
+      content.each_line do |line|
          if line =~ regDate
           inpost = false
           line = line.strip


### PR DESCRIPTION
...1.9. .each is depreciated on Strings in 1.8.

See [this issue](https://github.com/ttscoff/Slogger/issues/137) for reference.
