### PR TITLE
Added in fix for those still on Ruby 1.8. I now detect the version of Ru...

### DIFF
--- a/plugins_disabled/facebookifttt.rb
+++ b/plugins_disabled/facebookifttt.rb
@@ -80,7 +80,8 @@ class FacebookIFTTTLogger < Slogger
     f.close
 
     if !content.empty?
-      content.each_line do |line|
+      each_selector = RUBY_VERSION < "1.9.2" ? :each : :each_line
+      content.send(each_selector) do | line|
          if line =~ regDate
           inpost = false
           line = line.strip


### PR DESCRIPTION
...by and use the appropriate method on the line. This should fix [this](https://github.com/ttscoff/Slogger/commit/45ffa392166f83232389cfcf41983a165967a90f#commitcomment-3138104) issue for any future users of Slogger.
