### PR TITLE
A Runkeeper plugin for Slogger

### DIFF
--- a/plugins/runkeeper.rb
+++ b/plugins/runkeeper.rb
@@ -16,7 +16,6 @@
 config = {
     'runkeeper_description' => [
     'Gets runkeeper activity information'],
-    'runkeeper_app_id' => '',
     'runkeeper_access_token' => '',
     'runkeeper_tags' => '#activities #workout #runkeeper',
     'runkeeper_save_data_file' => '',


### PR DESCRIPTION
Retrieves recent Runkeeper activity and saves it to your Day One journal.

Based on Patrice Brend'amour's Fitbit plugin, this includes a gist link to a brief guide for getting the required Runkeeper API token.
