### PR TITLE
RunKeeper plugin: Added option for metric distances

### DIFF
--- a/plugins_disabled/runkeeper.rb
+++ b/plugins_disabled/runkeeper.rb
@@ -20,7 +20,7 @@ config = {
     'runkeeper_access_token' => '',
     'runkeeper_tags' => '#activities #workout #runkeeper',
     'runkeeper_save_data_file' => '',
-    'metric_distance' => false
+    'metric_distance' => false,
 }
 
 $slog.register_plugin({ 'class' => 'RunkeeperLogger', 'config' => config })


### PR DESCRIPTION
Added a configuration option to show the distances in kilometers instead of miles. 
