### PR TITLE
Fix to make tags work in YahooFinanace plugin.

### DIFF
--- a/plugins_disabled/yahoofinancelogger.rb
+++ b/plugins_disabled/yahoofinancelogger.rb
@@ -42,7 +42,7 @@ class YahooFinanceLogger < Slogger
     @log.info("Logging <YahooFinanceLogger> Tickers")
 
     tickers = config['tickers']
-    tags = config['tags'] || ''
+    @tags = config['tags'] || ''
     tags = "\n\n#{@tags}\n" unless @tags == ''
     show_details = (config['show_details'] == true)
 


### PR DESCRIPTION
Very small bug, probably a typo in the original code.
