### PR TITLE
Added digest option to PinboardLogger.

### DIFF
--- a/plugins/pinboardlogger.rb
+++ b/plugins/pinboardlogger.rb
@@ -9,6 +9,7 @@ Author: [Brett Terpstra](http://brettterpstra.com)
 Configuration:
   pinboard_feeds: [ 'http://feeds.pinboard.in/rss/u:username/']
   pinboard_tags: "#social #bookmarks"
+  pinboard_digest: true
 Notes:
 
 =end
@@ -19,6 +20,7 @@ config = {
   'pinboard_feeds' => [],
   'pinboard_tags' => '#social #bookmarks',
   'pinboard_save_hashtags' => true
+  'pinboard_digest' => true
 }
 $slog.register_plugin({ 'class' => 'PinboardLogger', 'config' => config })
 
@@ -56,17 +58,31 @@ class PinboardLogger < Slogger
         rss = RSS::Parser.parse(rss_content, false)
         feed_output = ''
         rss.items.each { |item|
+          feed_output = '' unless config['pinboard_digest']
           item_date = Time.parse(item.date.to_s) + Time.now.gmt_offset
           if item_date > @timespan
             content = ''
             post_tags = ''
-            content = "\n\n        " + item.description.gsub(/\n/,"\n        ").strip  unless item.description.nil?
+            if config['pinboard_digest']
+              content = "\n\n        " + item.description.gsub(/\n/, "\n        ").strip unless item.description.nil?
+            else
+              content = "\n\n> " + item.description.gsub(/\n/, "\n> ").strip unless item.description.nil?
+            end
             if config['pinboard_save_hashtags']
               post_tags = "\n    " + item.dc_subject.split(' ').map {|tag| "##{tag}"}.join(' ') + "\n" unless item.dc_subject.nil?
             end
-            feed_output += "* [#{item.title.gsub(/\n/,' ').strip}](#{item.link})#{content}\n#{post_tags}"
+            feed_output += "#{config['pinboard_digest'] ? '* ' : ''}[#{item.title.gsub(/\n/, ' ').strip}](#{item.link})#{content}#{post_tags}"
           else
             break
+          end
+          if config['pinboard_digest']
+            output = feed_output
+            unless output == ''
+              options = {}
+              options['datestamp'] = Time.parse(item.date.to_s).utc.iso8601
+              options['content'] = "## New Pinboard bookmark\n#{output}#{tags}"
+              sl.to_dayone(options)
+            end
           end
         }
         output += "#### [#{rss.channel.title}](#{rss.channel.link})\n\n" + feed_output + "\n" unless feed_output == ''
@@ -76,7 +92,7 @@ class PinboardLogger < Slogger
         return ''
       end
     end
-    unless output == ''
+    unless output == '' || !config['pinboard_digest']
       options = {}
       options['content'] = "## Pinboard bookmarks\n\n#{output}#{tags}"
       sl.to_dayone(options)


### PR DESCRIPTION
I prefer my individual saved pinboard bookmarks to be individual entries in my Day One.  If and only if you set the pinboard_digest option to false (default is true), then these modifications will parse the new bookmarks into individual Day One entries each timestamped with the time the bookmark was created.  Otherwise, if pinboard_digest is true the plugin will run as it did before.
