### PR TITLE
Require json so that Github plugin can be run via the --onlyrun flag

### DIFF
--- a/plugins/githublogger.rb
+++ b/plugins/githublogger.rb
@@ -17,6 +17,8 @@ config = {
 }
 $slog.register_plugin({ 'class' => 'GithubLogger', 'config' => config })
 
+require 'json'
+
 class GithubLogger < Slogger
 
   def do_log


### PR DESCRIPTION
Error triggers when Github plugin is run via the --o / --onlyrun flag due to json not being required.

``` bash
➜  Slogger git:(master) ✗ ./slogger -o github
Initializing Slogger v2.1 (2.1.0.5)...
  22:03:37         GithubLogger: Logging Github activity for BrettBukowski
/Users/brettbukowski/src/Slogger/plugins/githublogger.rb:52:in `do_log': uninitialized constant GithubLogger::JSON (NameError)
    from /Users/brettbukowski/src/Slogger/slogger.rb:256:in `block in run_plugins'
    from /Users/brettbukowski/src/Slogger/slogger.rb:243:in `each'
    from /Users/brettbukowski/src/Slogger/slogger.rb:243:in `run_plugins'
    from /Users/brettbukowski/src/Slogger/slogger.rb:387:in `<top (required)>'
    from /Users/brettbukowski/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/brettbukowski/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from ./slogger:18:in `<main>'
```
