### PR TITLE
Fix issues with Pinboard formatting

### DIFF
--- a/plugins/pinboardlogger.rb
+++ b/plugins/pinboardlogger.rb
@@ -65,14 +65,16 @@ class PinboardLogger < Slogger
             content = ''
             post_tags = ''
             if config['pinboard_digest']
-              content = "\n\n        " + item.description.gsub(/\n/, "\n        ").strip unless item.description.nil?
+              content = "\n        " + item.description.gsub(/\n/, "\n        ").strip unless item.description.nil?
             else
-              content = "\n\n> " + item.description.gsub(/\n/, "\n> ").strip unless item.description.nil?
+              content = "\n> " + item.description.gsub(/\n/, "\n> ").strip unless item.description.nil?
             end
+            content = "\n#{content}\n" unless content == ''
             if config['pinboard_save_hashtags']
               post_tags = "\n" + item.dc_subject.split(' ').map { |tag| "##{tag}" }.join(' ') + "\n" unless item.dc_subject.nil?
             end
-            feed_output += "#{config['pinboard_digest'] ? '* ' : ''}[#{item.title.gsub(/\n/, ' ').strip}](#{item.link})#{content}#{post_tags}"
+            post_tags = "\n#{post_tags}\n" unless post_tags == ''
+            feed_output += "#{config['pinboard_digest'] ? '* ' : ''}[#{item.title.gsub(/\n/, ' ').strip}](#{item.link})\n#{content}#{post_tags}"
           else
             break
           end


### PR DESCRIPTION
I was having issues with the Pinboard logger accidentally running items together. This would result in a blob of text that looked something like this:

```
## Pinboard bookmarks

#### [Pinboard (jeffmueller)](https://pinboard.in/u:jeffmueller/)

* [No, Rails' CookieStore isn't broken – Coffeepowered](https://coffeepowered.net/2013/09/26/rails-session-cookies)

        No, Rails' CookieStore isn't broken http://bit.ly/16HqTxn (http://bit.ly/19IVhUx) via @thibaut_barrere* [Logout is broken by default in Ruby on Rails Web applications | MaverickBlogging](http://maverickblogging.com/logout-is-broken-by-default-ruby-on-rails-web-applications/)

        CookieStore vulnerability in Rails 2.x, 3.x, 4.x. http://bit.ly/16HqURM (http://bit.ly/19IViHV)* [Revisiting All My Past Product Reviews and Recommendations: What Stuck and What Didn’t? — Shawn Blanc](http://shawnblanc.net/2013/10/revisiting-reviews-and-recommendations/)
* [API first architecture or the fat vs thin server debate](http://www.leaseweblabs.com/2013/10/api-first-architecture-fat-vs-thin-server-debate/)
* [The Science behind GTD](http://facilethings.com/blog/en/science)

        RT @FacileThings: The Science behind GTD http://bit.ly/17zjrjx #gtd #productivity | Proud of @gtdguy 's comment :)* [Wasted Time](http://the-northwind.com/blog/2013/10/9/wasted-time)
* [Wallflowers: my favorite OS X augmentations - BrettTerpstra.com](http://brettterpstra.com/2013/10/12/wallflowers-os-x-augmentation/)

#social #bookmarks
```

You can see that the issue is with items that are saved with a summary. This fixes the formatting issues that were occurring. I've been running it for over a week now, and none of the resulting entries have been ill-formatted.
