### PR TITLE
Replaced ASCII greater-than-or-equal-to with >= to resolve 'invalid multibyte char (US-ASCII)' error.

### DIFF
--- a/plugins_disabled/omnifocus.rb
+++ b/plugins_disabled/omnifocus.rb
@@ -78,9 +78,9 @@ class OmniFocusLogger < Slogger
           tell application id "com.omnigroup.OmniFocus"
           	tell default document
           		if filter is equal to "NONE" then
-          			set refDoneToday to a reference to (flattened tasks where (completion date ≥ dteToday))
+          			set refDoneToday to a reference to (flattened tasks where (completion date >= dteToday))
           		else
-          			set refDoneToday to a reference to (flattened tasks where (completion date ≥ dteToday) and name of containing project's folder = filter)
+          			set refDoneToday to a reference to (flattened tasks where (completion date >= dteToday) and name of containing project's folder = filter)
 			
           		end if
           		set {lstName, lstContext, lstProject, lstNote} to {name, name of its context, name of its containing project, note} of refDoneToday


### PR DESCRIPTION
This is basically a reapplication of commit 41b5a6e50eb3b90768f5aac5403e9165162452d8, from https://github.com/ttscoff/Slogger/pull/54. It looks like the multibyte character was added back in commit f298e93b6399943ba51df901ed4626bab6257237.
