### PR TITLE
Add line break to end of {note} to separate tasks

### DIFF
--- a/plugins_disabled/omnifocus.rb
+++ b/plugins_disabled/omnifocus.rb
@@ -167,7 +167,7 @@ class OmniFocusLogger < Slogger
             end
             if note != "null" && log_notes
               note = note.gsub("\\n","\n> ")
-              taskString += "*Notes:*\n> #{note}"
+              taskString += "*Notes:*\n> #{note}\n"
             end
                
             output += taskString


### PR DESCRIPTION
Without this, subsequent tasks appear under the first task’s note
