### PR TITLE
Set Omnifocus to read from 00:00:00.

### DIFF
--- a/plugins_disabled/omnifocus.rb
+++ b/plugins_disabled/omnifocus.rb
@@ -115,6 +115,9 @@ class OmniFocusLogger < Slogger
           	set year of t to (yy as integer)
           	set month of t to (mm as integer)
           	set day of t to (dd as integer)
+            set hours of t to 0
+            set minutes of t to 0
+            set seconds of t to 0
           	return t
           end setDate
 


### PR DESCRIPTION
The Omnifocus plugin relies on a setDate method to build a date on which
to look for completed tasks. However, setDate doesn't force a time
portion of the date and this causes AppleScript to default to the
current time of day. Thus, unless a task has been marked as completed in
the future, the plugin couldn't never return results for the current day. The
plugin also couldn't return entries from the first day of any multi-day
runs that occur before the present hh:mm:ss part of that day.

If I complete a task in Omnifocus at 13:01 and run slogger two minutes
later the effect is to ask Omnifocus, "what have I completed today,
since 13:03?", which is nothing. If I run slogger -t1 the next day at
15:00, I'm asking, "what did I complete yesterday, after 15:00?"

This is fixed by explicitly setting the time portion of the cut-off date
to the very beginning of the day, 00:00:00
