### PR TITLE
Fix omnifocus bugs

### DIFF
--- a/plugins_disabled/omnifocus.rb
+++ b/plugins_disabled/omnifocus.rb
@@ -170,7 +170,7 @@ class OmniFocusLogger < Slogger
             end
             if log_notes && note != "null" && note != "\n"
               note = note.gsub("\\n","\n> ")
-              taskString += "*Notes:*\n> #{note}"
+              taskString += "*Notes:*\n> #{note}\n"
             end
 
             output += taskString


### PR DESCRIPTION
This update will allow the OmniFocus plugin to work with both the AppStore version of OmniFocus as well as the non-AppStore version.

It also includes an update to not include empty notes. It attempted to do this previously, but failed to catch the empty state (containing a newline) precisely. 
