### PR TITLE
Support project specific vendor/bundle install option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ projectnotes.md
 bintest
 .fuse*
 .bundle
-vendor/ruby
+vendor/bundle

--- a/slogger.rb
+++ b/slogger.rb
@@ -8,6 +8,8 @@
 #        Copyright 2012, Brett Terpstra
 #              http://brettterpstra.com
 #                  --------------------
+require 'rubygems'
+require 'bundler/setup'
 require 'open-uri'
 require 'net/http'
 require 'net/https'


### PR DESCRIPTION
Bundler allows you to install required gems to a folder inside the project instead of the default gem install location. I added the require statements to slogger.rb (as per instructions on http://bundler.io) to load the bundled environment.

This should enable you to use 'bundle install --path vendor/bundle' (instead of 'bundle install') to install all gems required by slogger to a vendor/bundle folder inside the Slogger folder. 
