### PR TITLE
Asanalogger make starring of posts optional

### DIFF
--- a/plugins_disabled/asanalogger.rb
+++ b/plugins_disabled/asanalogger.rb
@@ -13,6 +13,7 @@ config = { # description and a primary key (username, url, etc.) required
                     'asana_api_key is a string with your personal Asana API key.',
                     'This can be obtained from your profile screen in Asana.'],
   'asana_api_key' => '',
+  'asana_star_posts' => true,
   'asana_tags' => '#tasks'
 }
 # Update the class key to match the unique classname below
@@ -74,7 +75,7 @@ class AsanaLogger < Slogger
     # set up day one post
     options = {}
     options['datestamp'] = Time.now.utc.iso8601
-    options['starred'] = true
+    options['starred'] = config['asana_star_posts']
     options['uuid'] = %x{uuidgen}.gsub(/-/,'').strip
 
     # Create a journal entry


### PR DESCRIPTION
This also fixes a require statement that was in uppercase, causing issues on case sensitive filesystems
