### PR TITLE
instagram plugin using api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ gem 'feed-normalizer'
 gem 'twitter', '~> 5.3.0'
 gem 'twitter_oauth'
 gem 'json'
+gem 'instagram'
+gem 'sinatra'
 
 gem 'nokogiri'
 

--- a/lib/dayone.rb
+++ b/lib/dayone.rb
@@ -33,6 +33,12 @@ class DayOne < Slogger
       end
     end
     starred = options['starred'] || false
+    if options['location']
+       location = true
+       lat = options['lat']
+       long = options['long']
+       place = options['place'] || ''
+    end
 
     # entry = CGI.escapeHTML(content.unpack('C*').pack('U*').gsub(/[^[:punct:]\w\s]+/,' ')) unless content.nil?
 

--- a/lib/instagram_server.rb
+++ b/lib/instagram_server.rb
@@ -1,0 +1,35 @@
+require 'rubygems'
+require "sinatra"
+require "instagram"
+
+CALLBACK_URL = "http://localhost:4567/oauth/callback"
+
+Instagram.configure do |config|
+  config.client_id = "3b878d6b67444f3c8bac914655bfe582"
+  config.client_secret = "9cd3c532cd6a495890b2d2850647c8d1"
+end
+
+def exit!
+  Process.kill "TERM", Process.pid
+end
+
+get "/" do
+  '<a href="/oauth/connect">Connect with Instagram</a>'
+end
+
+command = 'open http://localhost:4567'
+output = `#{command}`
+
+get "/oauth/connect" do
+  redirect Instagram.authorize_url(:redirect_uri => CALLBACK_URL)
+end
+
+get "/code/:code" do
+  "#{params[:code]}"
+end
+
+get "/oauth/callback" do
+  response = Instagram.get_access_token(params[:code], :redirect_uri => CALLBACK_URL)
+  exit!
+  "<h2>#{response.access_token}</h2><br></p>Head back to the terminal and paste in the code above</p>"
+end

--- a/plugins_disabled/instagram.rb
+++ b/plugins_disabled/instagram.rb
@@ -1,0 +1,143 @@
+=begin
+Plugin: My New Logger
+Description: Brief description (one line)
+Author: [My Name](My URL)
+Configuration:
+  option_1_name: [ "example_value1" , "example_value2", ... ]
+  option_2_name: example_value
+Notes:
+  - multi-line notes with additional description and information (optional)
+=end
+
+config = { # description and a primary key (username, url, etc.) required
+  'description' => ['Logs your posts from Instagram',
+                    'No real setup required beyond needing to authenticate with the Instagram API.',
+                    'backdate (true/false) gives you the option to add the 20 most recent photos to Day One.'],
+  'tags' => '#social #instagram', # A good idea to provide this with an appropriate default setting
+  'backdate' => false,
+  'access_token' => ''
+}
+# Update the class key to match the unique classname below
+$slog.register_plugin({ 'class' => 'InstagramLogger', 'config' => config })
+
+require 'date'
+
+class Time
+    def to_datetime
+    # Convert seconds + microseconds into a fractional number of seconds
+    seconds = sec + Rational(usec, 10**6)
+
+    # Convert a UTC offset measured in minutes to one measured in a
+    # fraction of a day.
+    offset = Rational(utc_offset, 60 * 60 * 24)
+    DateTime.new(year, month, day, hour, min, seconds, offset)
+    end
+end
+
+require 'instagram'
+require 'rubygems'
+
+# unique class name: leave '< Slogger' but change InstagramLogger (e.g. LastFMLogger)
+class InstagramLogger < Slogger
+
+  def do_log
+    if @config.key?(self.class.name)
+      @instagram_config = @config[self.class.name]
+      # check for a required key to determine whether setup has been completed or not
+      if !@instagram_config.key?('InstagramLogger_last_run') || @instagram_config['InstagramLogger_last_run'] == ""
+        @log.warn("<Service> has not been configured or an option is invalid, please edit your slogger_config file.")
+        return
+      end
+    else
+      @log.warn("Instagram users have not been configured, please edit your slogger_config file.")
+      return
+    end
+
+    if !@instagram_config.key?('access_token') || @instagram_config['access_token'] == ''
+      @log.info("Instagram requires configuration, please run from the command line and follow the prompts")
+      puts
+      puts "------------- Instagram Configuration --------------"
+      puts "\nSlogger will now open an authorization page in your default web browser. Copy the code you receive and return here.\n\n"
+      puts "Press Enter to continue..."
+      keypress = gets
+      command = "/usr/bin/ruby lib/instagram_server.rb"
+      output = `#{command}`
+      puts "\n\n\n------------- Authentication Started -------------\n\n"
+      print "Paste the code you received here: "
+      output
+      code = gets.strip
+      @instagram_config['access_token'] = code
+      log.info("Instagram successfully configured, run Slogger again to continue")
+      return @instagram_config
+    end
+
+    @instagram_config['instagram_tags'] ||= '#social #instagram'
+    tags = "\n\n#{@instagram_config['instagram_tags']}\n" unless @instagram_config['instagram_tags'] == ''
+
+    today = @timespan
+
+    Instagram.configure do |config|
+      config.client_id = '3b878d6b67444f3c8bac914655bfe582'
+      config.client_secret = '9cd3c532cd6a495890b2d2850647c8d1'
+    end
+
+
+    client = Instagram.client(:access_token => @instagram_config['access_token'])
+    user = client.user
+    instagram_media = client.user_recent_media
+    begin
+      instagram_media.each do |media|
+        time_created = media['created_time'].to_i
+        if !@instagram_config['backdate']
+          break if Time.at(time_created) < today
+        end
+        image_url = media['images']['standard_resolution']['url']
+        location_data = media['location'] unless media['location'] == nil
+        likes_data = client.media_likes(media['id']) unless media['likes']['count'] == 0
+        caption = media['caption']['text'] unless media['caption'] == nil
+        
+        comments = ""
+        if media['comments']['count'] != 0
+          comments += "### Comments\n\n"
+          media['comments']['data'].each do |comment|
+            comments += ">" + comment['text'] + " - " + comment['from']['full_name'] + "\n"
+          end
+        end
+        
+        like_names = likes_data.map{|n| n['full_name'] == "" ? n['username'] : n['full_name']} unless media['likes']['count'] == 0
+
+        likes = ""
+        if media['likes']['count'] != 0
+          likes += "### #{media['likes']['count']} Likes\n\n"
+          likes += like_names.join(", ")
+        end
+
+        # create an options array to pass to 'to_dayone'
+        # all options have default fallbacks, so you only need to create the options you want to specify
+        options = {}
+        options['content'] = "## Instagram Photo\n\n#{caption}\n#{comments}\n#{likes}\n\n#{tags}"
+        options['datestamp'] = Time.at(time_created).utc.iso8601
+        options['starred'] = false
+        options['uuid'] = %x{uuidgen}.gsub(/-/,'').strip
+
+        if location_data
+          options['location'] = true
+          options['lat'] = location_data['latitude']
+          options['long'] = location_data['longitude']
+          options['place'] = location_data['name'] || false
+        end
+
+
+        # Create a journal entry
+        # to_dayone accepts all of the above options as a hash
+        # generates an entry base on the datestamp key or defaults to "now"
+        sl = DayOne.new
+        sl.to_dayone(options)
+        sl.save_image(image_url, options['uuid'])
+      end
+    end
+    @instagram_config['backdate'] = false
+    return @instagram_config
+
+  end
+end

--- a/slogger.rb
+++ b/slogger.rb
@@ -314,6 +314,19 @@ class Slogger
   </dict>
   <key>Entry Text</key>
   <string><%= entry %></string>
+  <% if location %><key>Location</key>
+  <dict>
+  <key>Administrative Area</key>
+  <string></string>
+  <key>Country</key>
+  <string></string>
+  <key>Latitude</key>
+  <real><%= lat %></real>
+  <key>Longitude</key>
+  <real><%= long %></real>
+  <key>Place Name</key>
+  <string><% if place %><%= place %><% end %></string>
+  </dict><% end %>
   <key>Starred</key>
   <<%= starred %>/>
   <% if tags %><key>Tags</key>


### PR DESCRIPTION
Adding Instagram plugin to Slogger.

Advantage over an IFTT rule is that you get:
- Like count
- Who liked your photo
- Comments
- Location, if included (also place name if you used Foursquare)

Timestamps for the post are set as the time the photo was posted, not the time Slogger was run.

Example entry:

![](https://dl.dropboxusercontent.com/s/g05qf971aa4kitq/Screenshot%202014-09-03%2022.44.04.png?dl=0)

I've been using this for about a year now with no issues. The authentication flow is meant to be low effort and opens a local server, which allows the user to then enter their auth key directly in the terminal once they've approved the app.
