### PR TITLE
Pin the rmagick version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'sinatra'
 gem 'nokogiri'
 gem 'digest' # required for feedafever
 gem 'sqlite3' # required for feedafever
-gem 'rmagick' # required for lastfmcovers
+gem 'rmagick', '2.13.2' # required for lastfmcovers
 gem 'multimap' # required for olivetree
 
 group :test do


### PR DESCRIPTION
To fix installation with the latest (broken) version of rmagick:

- https://github.com/ttscoff/Slogger/issues/344
- http://stackoverflow.com/questions/28247947/fail-to-install-rmagick-on-mac-10-9-5