### PR TITLE
Split Plugins into Gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ end
 gem 'feed-normalizer'
 gem 'twitter', '~> 5.3.0'
 gem 'twitter_oauth'
-gem 'json'
 gem 'instagram'
 gem 'sinatra'
 
@@ -21,6 +20,7 @@ gem 'multimap' # required for olivetree
 gem 'pry'
 
 plugin "blogger"
+plugin "githublogger"
 
 group :test do
   gem 'rake'

--- a/Gemfile
+++ b/Gemfile
@@ -28,4 +28,3 @@ group :test do
   gem 'vcr'
   gem 'webmock'
 end
-

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
 def plugin(name)
-  gemname = "sloggerplugin-#{name}"
-  path = "../#{gemname}"
-  gem gemname, path: path
+  gem_name = "sloggerplugin-#{name}"
+  github_path = "sloggerplugins/#{name}"
+  gem gem_name, github: github_path
 end
 
 gem 'feed-normalizer'
@@ -21,7 +21,6 @@ gem 'multimap' # required for olivetree
 gem 'pry'
 
 plugin "blogger"
-
 
 group :test do
   gem 'rake'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,11 @@
 source 'https://rubygems.org'
 
+def plugin(name)
+  gemname = "sloggerplugin-#{name}"
+  path = "../#{gemname}"
+  gem gemname, path: path
+end
+
 gem 'feed-normalizer'
 gem 'twitter', '~> 5.3.0'
 gem 'twitter_oauth'
@@ -12,6 +18,10 @@ gem 'digest' # required for feedafever
 gem 'sqlite3' # required for feedafever
 gem 'rmagick', '2.13.2' # required for lastfmcovers
 gem 'multimap' # required for olivetree
+gem 'pry'
+
+plugin "blogger"
+
 
 group :test do
   gem 'rake'
@@ -19,3 +29,4 @@ group :test do
   gem 'vcr'
   gem 'webmock'
 end
+

--- a/MOVING_NOTES.md
+++ b/MOVING_NOTES.md
@@ -1,1 +1,0 @@
-* needed to change the config so that the class name was dynamic

--- a/MOVING_NOTES.md
+++ b/MOVING_NOTES.md
@@ -1,0 +1,1 @@
+* needed to change the config so that the class name was dynamic

--- a/slogger.rb
+++ b/slogger.rb
@@ -261,17 +261,16 @@ class Slogger
     @config['last_run_time'] = Time.now.strftime('%c')
     new_options = false
     plugin_dir = $options[:develop] ? "/plugins_develop/*.rb" : "/plugins/*.rb"
-    # Dir[SLOGGER_HOME + plugin_dir].each do |file|
-    #   if $options[:onlyrun]
-    #     $options[:onlyrun].each { |plugin_frag|
-    #       if File.basename(file) =~ /^#{plugin_frag}/i
-    #         require file
-    #       end
-    #     }
-    #   else
-    #     require file
-    #   end
-    # end
+    installed_plugins = Gem.loaded_specs.find_all do |name, info|
+      name.start_with?("sloggerplugin-")
+    end
+    installed_plugins.each do |name, info|
+      require name.gsub("-", "/")
+    end
+    Sloggerplugin.constants.each do |plugin_module|
+      Sloggerplugin.const_get(plugin_module)::Runner.register
+    end
+
     require 'pry'
     binding.pry
     @plugins.each do |plugin|

--- a/slogger.rb
+++ b/slogger.rb
@@ -270,8 +270,6 @@ class Slogger
       Sloggerplugin.const_get(plugin_module)::Runner.register
     end
 
-    require 'pry'
-    binding.pry
     @plugins.each do |plugin|
       _namespace = plugin['class'].to_s
 

--- a/slogger.rb
+++ b/slogger.rb
@@ -267,10 +267,10 @@ class Slogger
       require name.gsub("-", "/")
     end
     Sloggerplugin.constants.each do |plugin_module|
-      @plugins << Sloggerplugin.const_get(plugin_module)::Runner
+      plugins << Sloggerplugin.const_get(plugin_module)::Runner
     end
 
-    @plugins.each do |plugin|
+    plugins.each do |plugin|
       _namespace = plugin.class.to_s
 
       @config[_namespace] ||= {}
@@ -294,9 +294,8 @@ class Slogger
     ConfigTools.new({'config_file' => $options[:config_file]}).dump_config(@config)
   end
 
-  def register_plugin(_)
-    #no op
-    false
+  def register_plugin(plugin)
+    @plugins.push plugin
   end
 
   def template

--- a/slogger.rb
+++ b/slogger.rb
@@ -267,14 +267,14 @@ class Slogger
       require name.gsub("-", "/")
     end
     Sloggerplugin.constants.each do |plugin_module|
-      Sloggerplugin.const_get(plugin_module)::Runner.register
+      @plugins << Sloggerplugin.const_get(plugin_module)::Runner
     end
 
     @plugins.each do |plugin|
-      _namespace = plugin['class'].to_s
+      _namespace = plugin.class.to_s
 
       @config[_namespace] ||= {}
-      plugin['config'].each do |k,v|
+      plugin.config.each do |k,v|
         if @config[_namespace][k].nil?
           new_options = true
           @config[_namespace][k] ||= v
@@ -283,7 +283,7 @@ class Slogger
       end
       unless $options[:config_only]
         # credit to Hilton Lipschitz (@hiltmon)
-        updated_config = eval(plugin['class']).new.do_log
+        updated_config  = plugin.new.do_log
         if updated_config && updated_config.class.to_s == 'Hash'
             updated_config.each { |k,v|
               @config[_namespace][k] = v
@@ -294,8 +294,9 @@ class Slogger
     ConfigTools.new({'config_file' => $options[:config_file]}).dump_config(@config)
   end
 
-  def register_plugin(plugin)
-    @plugins.push plugin
+  def register_plugin(_)
+    #no op
+    false
   end
 
   def template

--- a/slogger.rb
+++ b/slogger.rb
@@ -257,18 +257,29 @@ class Slogger
 	end
   end
 
-  def run_plugins
-    @config['last_run_time'] = Time.now.strftime('%c')
-    new_options = false
-    installed_plugins = Gem.loaded_specs.find_all do |name, info|
+  def installed_plugins
+    @installed_plugins ||= Gem.loaded_specs.find_all do |name, info|
       name.start_with?("sloggerplugin-")
     end
+  end
+
+  def require_installed_plugins
     installed_plugins.each do |name, info|
       require name.gsub("-", "/")
     end
+  end
+
+  def load_plugins
     Sloggerplugin.constants.each do |plugin_module|
       plugins << Sloggerplugin.const_get(plugin_module)::Runner
     end
+  end
+
+  def run_plugins
+    @config['last_run_time'] = Time.now.strftime('%c')
+    new_options = false
+    require_installed_plugins
+    load_plugins
 
     plugins.each do |plugin|
       _namespace = plugin.class.to_s

--- a/slogger.rb
+++ b/slogger.rb
@@ -153,8 +153,8 @@ end
 
 class Slogger
 
-  attr_accessor :config, :dayonepath, :plugins
-  attr_reader :timespan, :log
+  attr_accessor :config, :dayonepath, :plugins, :log
+  attr_reader :timespan
   def initialize
     cfg = ConfigTools.new({'config_file' => $options[:config_file]})
     @log = Logger.new(STDERR)
@@ -201,7 +201,10 @@ class Slogger
 
     @to = $options[:to]
     @from = $options[:from]
+  end
 
+  def options
+    $options
   end
 
   def undo_slogger(count = 1)
@@ -294,7 +297,7 @@ class Slogger
       end
       unless $options[:config_only]
         # credit to Hilton Lipschitz (@hiltmon)
-        updated_config  = plugin.new.do_log
+        updated_config  = plugin.new.do_log(self)
         if updated_config && updated_config.class.to_s == 'Hash'
             updated_config.each { |k,v|
               @config[_namespace][k] = v

--- a/slogger.rb
+++ b/slogger.rb
@@ -22,7 +22,6 @@ require 'optparse'
 require 'fileutils'
 require 'rexml/parsers/pullparser'
 require 'rubygems'
-require 'json'
 
 SLOGGER_HOME = File.dirname(File.expand_path(__FILE__))
 ENV['SLOGGER_HOME'] = SLOGGER_HOME
@@ -30,7 +29,6 @@ ENV['SLOGGER_HOME'] = SLOGGER_HOME
 require SLOGGER_HOME + '/lib/sociallogger'
 require SLOGGER_HOME + '/lib/configtools'
 require SLOGGER_HOME + '/lib/plist.rb'
-# require SLOGGER_HOME + '/lib/json'
 require SLOGGER_HOME + '/lib/levenshtein-0.2.2/lib/levenshtein.rb'
 
 if RUBY_VERSION.to_f > 1.9
@@ -154,7 +152,7 @@ end
 class Slogger
 
   attr_accessor :config, :dayonepath, :plugins, :log
-  attr_reader :timespan
+  attr_reader :timespan, :date_format
   def initialize
     cfg = ConfigTools.new({'config_file' => $options[:config_file]})
     @log = Logger.new(STDERR)
@@ -285,7 +283,7 @@ class Slogger
     load_plugins
 
     plugins.each do |plugin|
-      _namespace = plugin.class.to_s
+      _namespace = plugin.name
 
       @config[_namespace] ||= {}
       plugin.config.each do |k,v|

--- a/slogger.rb
+++ b/slogger.rb
@@ -260,7 +260,6 @@ class Slogger
   def run_plugins
     @config['last_run_time'] = Time.now.strftime('%c')
     new_options = false
-    plugin_dir = $options[:develop] ? "/plugins_develop/*.rb" : "/plugins/*.rb"
     installed_plugins = Gem.loaded_specs.find_all do |name, info|
       name.start_with?("sloggerplugin-")
     end

--- a/slogger.rb
+++ b/slogger.rb
@@ -261,17 +261,19 @@ class Slogger
     @config['last_run_time'] = Time.now.strftime('%c')
     new_options = false
     plugin_dir = $options[:develop] ? "/plugins_develop/*.rb" : "/plugins/*.rb"
-    Dir[SLOGGER_HOME + plugin_dir].each do |file|
-      if $options[:onlyrun]
-        $options[:onlyrun].each { |plugin_frag|
-          if File.basename(file) =~ /^#{plugin_frag}/i
-            require file
-          end
-        }
-      else
-        require file
-      end
-    end
+    # Dir[SLOGGER_HOME + plugin_dir].each do |file|
+    #   if $options[:onlyrun]
+    #     $options[:onlyrun].each { |plugin_frag|
+    #       if File.basename(file) =~ /^#{plugin_frag}/i
+    #         require file
+    #       end
+    #     }
+    #   else
+    #     require file
+    #   end
+    # end
+    require 'pry'
+    binding.pry
     @plugins.each do |plugin|
       _namespace = plugin['class'].to_s
 


### PR DESCRIPTION
This PR comes from a long running discussion/PR here: https://github.com/ttscoff/Slogger/pull/275

This makes a few changes:
- Moves the plugins completely out of the same repo as the main script
- Removes the inheritance from the the plugin classes themselves. This makes it easier to work with any changes in the main script or in the plugins by decoupling the two.
- Adds a small function in the gemfile to make it very easy to install plugins via GitHub. Plugin authors could of course publish their gems to rubygems but it's probably unnecessary for the most part.
- When a plugin is added to the gemfile, it is automatically "enabled". This makes it very easy to add and start using new plugins. If you want to disable a plugin, simply comment it out.

This PR itself doesn't remove the plugins yet. I only extract one plugin and added it as a gem that is a pretty large task in itself, automating the text changes is going to be tricky and I haven't started it yet. It would have been easier to keep the structure of the plugin classes the same during the move but I think cleaning this up while we're in here makes the most sense. If we made these changes later it would be a breaking change that would be very hard to update across all plugins.

If anyone has opinions on this, please me know. Otherwise I'm going to move forward with this as planned and start putting together a script to extract all the plugins to their own gems and put them on GH under the sloggerplugins org.

Here is the extract gem for the blogger plugin: https://github.com/sloggerplugins/blogger
The only interesting file is the Runner file which is the only file that is not just a generated gem file: https://github.com/sloggerplugins/blogger/blob/master/lib/sloggerplugin/blogger.rb

cc @mrjcleaver @drallgood 

Below are notes on moving forward what would need to happen to get the plugins out and usable.

Steps for moving each plugin to a gem:
- pull the config variable into a class method instead of local variable
- remove the call to the global register plugin method
- update the do_log method to take in the slogger object
- Update any references to `@log`, `@config` and `$options` to use the slogger object instead.
- Create the basic gem using `bundle gem <name>`
- Create a class inside the module called `Runner`
- Move the class from the plugin into the new Runner class.
- Update the Gemspec that is output to remove the TODO and other defaults. If you leave a TODO in, bundler won't let you use the Gem.
- Add a generic README to the Gem that explains what it is, does and link back to the main slogger project.
- Init the git repo, add it, commit.
- Create a repo on the sloggerplugiuns org
- Push the plugin to GitHub
- If the plugin is in the `plugins` directory then add it to do the Gemfile for the main project.
- If the plugin is in the `plugins_disabled` directory then add it to the Gemfile, commented out. - Open to opinion on this one.
- Lather, rinse, repeat.
