### PR TITLE
Fix for missing subtasks in The Hit List plugin

### DIFF
--- a/plugins_disabled/thehitlist.rb
+++ b/plugins_disabled/thehitlist.rb
@@ -197,6 +197,8 @@ class TheHitListLogger < Slogger
                 # add the task title to the text
                 if (length of subtaskText > 0) and (length of taskText = 0) then
                     set taskText to taskPrefix & taskTitle & linefeed & subtaskText
+                else if (length of subtaskText > 0) then
+                    set taskText to taskText & linefeed & subtaskText
                 end if
             end if
             


### PR DESCRIPTION
Fixes an issue where subtasks of a task completed on the check date
would be incorrectly skipped. They should be included if they were also completed on the check date.