### PR TITLE
Remove multimap dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'multimap' # required for olivetree
 
 group :test do
   gem 'rake'
-  gem 'rspec'
+  gem 'rspec', '< 3.0'
   gem 'vcr'
   gem 'webmock'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem 'nokogiri'
 gem 'digest' # required for feedafever
 gem 'sqlite3' # required for feedafever
 gem 'rmagick', '2.13.2' # required for lastfmcovers
-gem 'multimap' # required for olivetree
 
 group :test do
   gem 'rake'

--- a/plugins_disabled/olivetree.rb
+++ b/plugins_disabled/olivetree.rb
@@ -128,11 +128,11 @@ class OTBibleLogger < Slogger
 
     # Now we're going on a tag hunt
     # This was within each annotation find, but that was slow and silly
-    tagAssocs = Multimap.new
+    tagAssocs = Hash.new([])
     doc.elements.each('/syncables/syncable/data-type[text()="AnnotationUserTag"]/..') do |e|
       annotationID = e.elements['datum/annotation-id'].text unless e.elements['datum/annotation-id'].nil?
       userTagID = e.elements['datum/user-tag-id'].text unless e.elements['datum/user-tag-id'].nil?
-      tagAssocs[annotationID] = userTagID
+      tagAssocs[annotationID] << userTagID
     end
 
     annos = REXML::XPath.match(doc, '/syncables/syncable/data-type[text()="Annotation"]/..')


### PR DESCRIPTION
Switches the Olivetree slogger to use a hash instead of Multimap so we can remove the Gemfile dependency on Multimap.

If needed, I can write up some specs - but that'd be easier if I had some sample output available for Olivetree. That said, this is a fairly small change that should provide the same interface as Multimap provided - sans dependencies.